### PR TITLE
Added a modulo to the s:hash function

### DIFF
--- a/plugin/vim-jdb.vim
+++ b/plugin/vim-jdb.vim
@@ -51,6 +51,8 @@ sign define currentline text=-> texthl=Search
 
 let s:job = ''
 let s:channel = ''
+let s:max_signed_int = 2147483648
+lockvar s:max_signed_int
 
 function! s:hash(name, linenumber)
   let l:result = 1
@@ -58,7 +60,7 @@ function! s:hash(name, linenumber)
     let l:result = (l:result * 2) + char2nr(c)
   endfor
   let l:result = (l:result * 2) + a:linenumber
-  return l:result
+  return l:result % s:max_signed_int
 endfunction
 
 function! s:getClassNameFromFile(filename)


### PR DESCRIPTION
 It seems that the range command does not handle values which are larger than a signed int32. The modulo insures that the result will be less than the max signed int32.